### PR TITLE
Fix bug when fetching more than n_papers

### DIFF
--- a/pyrxiv/cli/cli.py
+++ b/pyrxiv/cli/cli.py
@@ -78,7 +78,10 @@ def run_search_and_download(
         length=n_papers, label="Downloading and processing papers"
     ) as bar:
         while len(pattern_papers) < n_papers:
-            papers = fetcher.fetch()
+            papers = fetcher.fetch(
+                n_papers=n_papers,
+                n_pattern_papers=len(pattern_papers),
+            )
             for paper in papers:
                 pdf_path = downloader.download_pdf(arxiv_paper=paper)
                 text = extractor.get_text(pdf_path=pdf_path, loader=loader)

--- a/pyrxiv/fetch.py
+++ b/pyrxiv/fetch.py
@@ -142,12 +142,20 @@ class ArxivFetcher:
             return paper_id_norm[0] > reference_id_norm[0]
         return False
 
-    def fetch(self, write: bool = True) -> list[ArxivPaper]:
+    def fetch(
+        self,
+        n_papers: int,
+        n_pattern_papers: int = 0,
+        write: bool = True,
+    ) -> list[ArxivPaper]:
         """
         Fetch new papers from arXiv, skipping already fetched ones, and stores their metadata in an `ArxivPaper`
         pydantic models. The newest fetched arXiv ID will be stored in `fetched_arxiv_ids.txt`.
 
         Args:
+            n_papers (int): The number of papers to fetch from arXiv.
+            n_pattern_papers (int, optional): The number of papers to fetch that match a specific regex pattern.
+                This is useful for fetching papers that match a specific pattern, e.g., "cond-mat.str-el". Defaults to 0.
             write (bool, optional): If True, the fetched papers will be written to the `fetched_arxiv_ids.txt` file.
                 Defaults to True.
 
@@ -155,7 +163,10 @@ class ArxivFetcher:
             list[ArxivPaper]: A list of `ArxivPaper` objects with the metadata of the papers fetched from arXiv.
         """
         papers: list[ArxivPaper] = []
-        while len(papers) < self.max_results:
+        while (
+            len(papers) < self.max_results
+            and (len(papers) + n_pattern_papers) < n_papers
+        ):
             remaining = self.max_results - len(papers)  # remaining papers to fetch
             current_batch_size = min(self.max_results, remaining)
 

--- a/tests/test_fetch.py
+++ b/tests/test_fetch.py
@@ -258,7 +258,7 @@ class TestArxivFetcher:
         mock_urlopen.return_value = mock_response
 
         fetcher = ArxivFetcher(max_results=1, download_path=Path("tests/data"))
-        papers = fetcher.fetch(write=False)
+        papers = fetcher.fetch(n_papers=1, write=False)
         if log_msg:
             assert len(cleared_log_storage) in [1, 2]
             assert cleared_log_storage[0]["level"] == log_msg["level"]


### PR DESCRIPTION
This pull request introduces changes to enhance the flexibility of the `fetch` method in `pyrxiv`, allowing for more granular control over the number of papers fetched and their patterns. The updates also ensure compatibility with the new method signature in related parts of the codebase, including CLI operations and tests.

### Enhancements to `fetch` method:

* [`pyrxiv/fetch.py`](diffhunk://#diff-79fbc5613324011b9184e6bc22c6823fdca47edf120710ee7e754f0e67f80654L145-R169): Updated the `fetch` method to accept two new parameters, `n_papers` and `n_pattern_papers`, enabling users to specify the total number of papers to fetch and the number of pattern-matching papers. Adjusted the loop condition to account for these parameters.

### Integration with CLI:

* [`pyrxiv/cli/cli.py`](diffhunk://#diff-a6f6beba057729f3f6fed814a0ed196b993780a6dbb72bbe06c58334b15ceb3aL81-R84): Modified the `run_search_and_download` function to pass the new `n_papers` and `n_pattern_papers` arguments to the `fetch` method, ensuring seamless integration with the enhanced functionality.

### Test updates:

* [`tests/test_fetch.py`](diffhunk://#diff-741677fa202f1c2c2d8120421978f6dee189aed5bd856791adc03a61c965d53aL261-R261): Updated the `test_fetch` function to include the new `n_papers` parameter in calls to the `fetch` method, maintaining test compatibility with the updated signature.