### PR TITLE
Move logger messages to file + Add subgroup arxiv_paper to hdf5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -179,6 +179,4 @@ artifacts
 tmp/
 
 # data folder
-data/*.pdf
-data/*.txt
-data/*.hdf5
+data*

--- a/pyrxiv/cli/cli.py
+++ b/pyrxiv/cli/cli.py
@@ -120,6 +120,10 @@ def run_search_and_download(
                 if regex and not regex.search(text):
                     pdf_path.unlink()
                     continue
+                logger.info(
+                    f"Paper {paper.id} matches the regex pattern: {regex_pattern}."
+                    " Storing metadata and text in an HDF5 file."
+                )
 
                 # If the paper matches the regex_pattern, store text in the corresponding ArxivPaper object
                 paper.text = text

--- a/pyrxiv/datamodel.py
+++ b/pyrxiv/datamodel.py
@@ -70,6 +70,7 @@ class ArxivPaper(BaseModel):
 
     def to_hdf5(self, hdf_file: h5py.File) -> h5py.Group:
         group = hdf_file.require_group(self.id)
+        sub_group = group.require_group("arxiv_paper")
         for key in self.model_fields:
             value = getattr(self, key)
             if key == "id":
@@ -79,8 +80,12 @@ class ArxivPaper(BaseModel):
             elif key == "authors":
                 value = [author.name for author in self.authors]
 
+            # Skip none values
+            if value is None:
+                continue
+
             # overwrite existing dataset
-            if key in group:
-                del group[key]
-            group.create_dataset(key, data=value)
+            if key in sub_group:
+                del sub_group[key]
+            sub_group.create_dataset(key, data=value)
         return group

--- a/pyrxiv/download.py
+++ b/pyrxiv/download.py
@@ -49,7 +49,8 @@ class ArxivDownloader:
                         if chunk:
                             f.write(chunk)
 
-            self.logger.info(f"PDF downloaded: {pdf_path}")
+            # ! too many messages, so I commented this out
+            # self.logger.info(f"PDF downloaded: {pdf_path}")
         except requests.exceptions.RequestException as e:
             self.logger.error(f"Failed to download PDF: {e}")
             pdf_path = None

--- a/pyrxiv/fetch.py
+++ b/pyrxiv/fetch.py
@@ -260,7 +260,8 @@ class ArxivFetcher:
                     )
                 )
 
-                self.logger.info(f"Paper {arxiv_id} fetched from arXiv.")
+                # ! too many messages, so I commented this out
+                # self.logger.info(f"Paper {arxiv_id} fetched from arXiv.")
 
                 # Making sure we do not exceed the number of papers to fetch
                 if len(papers) >= self.max_results:

--- a/pyrxiv/logger.py
+++ b/pyrxiv/logger.py
@@ -1,6 +1,5 @@
 import copy
 import logging
-import sys
 
 import structlog
 
@@ -26,7 +25,9 @@ def store_log_message(_, __, event_dict):
 logging.basicConfig(
     level=logging.INFO,
     format="%(message)s",
-    stream=sys.stdout,
+    # stream=sys.stdout,
+    filename="./data/logs.json",
+    filemode="w",
 )
 
 
@@ -43,7 +44,8 @@ structlog.configure(
             ]
         ),
         store_log_message,
-        structlog.dev.ConsoleRenderer(),
+        # structlog.dev.ConsoleRenderer(),
+        structlog.processors.JSONRenderer(),
     ],
     logger_factory=structlog.stdlib.LoggerFactory(),  # Use stdlib logger backend
     wrapper_class=structlog.make_filtering_bound_logger(logging.DEBUG),

--- a/tests/test_download.py
+++ b/tests/test_download.py
@@ -8,11 +8,12 @@ from tests.conftest import generate_arxiv_paper
 
 class TestArxivDownloader:
     @pytest.mark.parametrize(
-        "id, pdf_path_result, log_msg",
+        "id, pdf_path_result, len_logs, log_msg",
         [
             (
                 "1234.5678v1",
                 None,
+                1,
                 {
                     "level": "error",
                     "event": "Failed to download PDF: 404 Client Error: Not Found for url: http://arxiv.org/pdf/1234.5678v1",
@@ -21,15 +22,18 @@ class TestArxivDownloader:
             (
                 "2502.10309v1",
                 Path("tests/data/2502.10309v1.pdf"),
-                {
-                    "level": "info",
-                    "event": "PDF downloaded: tests/data/2502.10309v1.pdf",
-                },
+                0,
+                {},
             ),
         ],
     )
     def test_download_pdf(
-        self, cleared_log_storage: list, id: str, pdf_path_result: str, log_msg: dict
+        self,
+        cleared_log_storage: list,
+        id: str,
+        pdf_path_result: str,
+        len_logs: int,
+        log_msg: dict,
     ):
         """Tests the `download_pdf` method of the `ArxivFetcher` class."""
         arxiv_paper = generate_arxiv_paper(id=id)
@@ -37,6 +41,7 @@ class TestArxivDownloader:
         # no writing to file
         pdf_path = arxiv_downloader.download_pdf(arxiv_paper, write=False)
         assert pdf_path == pdf_path_result
-        assert len(cleared_log_storage) == 1
-        assert cleared_log_storage[0]["level"] == log_msg["level"]
-        assert cleared_log_storage[0]["event"] == log_msg["event"]
+        assert len(cleared_log_storage) == len_logs
+        if log_msg:
+            assert cleared_log_storage[0]["level"] == log_msg["level"]
+            assert cleared_log_storage[0]["event"] == log_msg["event"]


### PR DESCRIPTION
This pull request introduces several updates to logging, data serialization, and testing in the `pyrxiv` project. Key changes include improvements to logging configuration, adjustments to HDF5 serialization, and updates to tests to align with the modified logging behavior.

### Logging updates:
* Changed logging configuration to write logs to a JSON file (`./data/logs.json`) instead of streaming to `sys.stdout`, and replaced the console renderer with a JSON renderer (`pyrxiv/logger.py`) [[1]](diffhunk://#diff-2ba1780cad27fdcf0bbb5352d77a5454bc587c1a230ed413e6116fab31d6bfe4L29-R30) [[2]](diffhunk://#diff-2ba1780cad27fdcf0bbb5352d77a5454bc587c1a230ed413e6116fab31d6bfe4L46-R48).
* Commented out excessive logging messages in `download_pdf` and `fetch` methods to reduce noise (`pyrxiv/download.py`, `pyrxiv/fetch.py`) [[1]](diffhunk://#diff-729c90e9ffdb4da58debf9954df270ce7df802b6a9b82ec2ebf18f035f175f6bL52-R53) [[2]](diffhunk://#diff-79fbc5613324011b9184e6bc22c6823fdca47edf120710ee7e754f0e67f80654L263-R264).

### Data serialization updates:
* Added a nested subgroup (`arxiv_paper`) for better organization of HDF5 data and ensured `None` values are skipped during serialization in `to_hdf5` (`pyrxiv/datamodel.py`) [[1]](diffhunk://#diff-00d75af18dde30c16e8edacf7147bc240c2d91c23d1580172ab0dd2851b57895R73) [[2]](diffhunk://#diff-00d75af18dde30c16e8edacf7147bc240c2d91c23d1580172ab0dd2851b57895R83-R90).

### Testing updates:
* Updated tests for `download_pdf` to account for the modified logging behavior, including checking the length of log storage and handling cases with no log messages (`tests/test_download.py`) [[1]](diffhunk://#diff-b918cfaffb9f8f78fe453482131da561f565b9aaf98b4df54989a1c04ccb452aL11-R16) [[2]](diffhunk://#diff-b918cfaffb9f8f78fe453482131da561f565b9aaf98b4df54989a1c04ccb452aL24-R45).

### Minor changes:
* Removed an unused import (`sys`) from `pyrxiv/logger.py`.
* Added an informational log message in `run_search_and_download` to indicate when a paper matches the regex pattern (`pyrxiv/cli/cli.py`).