### PR TITLE
Fix the batch issue (yet again) and pdfloader issue

### DIFF
--- a/pyrxiv/cli/cli.py
+++ b/pyrxiv/cli/cli.py
@@ -106,8 +106,13 @@ def run_search_and_download(
                 n_pattern_papers=len(pattern_papers),
             )
             for paper in papers:
-                pdf_path = downloader.download_pdf(arxiv_paper=paper)
-                text = extractor.get_text(pdf_path=pdf_path, loader=loader)
+                try:
+                    pdf_path = downloader.download_pdf(arxiv_paper=paper)
+                    text = extractor.get_text(pdf_path=pdf_path, loader=loader)
+                except Exception as e:
+                    logger.error(f"Error processing paper {paper.id}: {e}")
+                    continue
+
                 if not text:
                     logger.info("No text extracted from the PDF.")
                     continue

--- a/pyrxiv/fetch.py
+++ b/pyrxiv/fetch.py
@@ -1,3 +1,4 @@
+import random
 import re
 import urllib.request
 from pathlib import Path
@@ -53,13 +54,12 @@ def get_batch_response(
     batch = data_dict.get("feed", {}).get("entry", [])
     if not batch and recursion:
         # try again with a different `max_results`
-        DECREMENT_FOR_RETRY = 49  # Used to avoid repeated empty batches
-        new_max_results = max(1, max_results - DECREMENT_FOR_RETRY)
+        new_max_results = random.randrange(max_results)  # 0 <= value < max_results
         batch = get_batch_response(
             category=category,
             start_index=start_index,
             max_results=new_max_results,
-            recursion=False,
+            recursion=True,
         )
         if not batch:
             logger.info("No papers found in the response")

--- a/pyrxiv/fetch.py
+++ b/pyrxiv/fetch.py
@@ -18,29 +18,29 @@ def get_batch_response(
     start_index: int = 0,
     max_results: int = 100,
     iteration: int = 0,
-    max__iteration: int = 10,
+    max_iteration: int = 10,
     logger: "BoundLoggerLazyProxy" = logger,
 ) -> list | dict:
     """
     Fetch a batch of papers from arXiv API based on the specified category, start index, and maximum results.
 
     NOTE: This function is happening because of a weird behavior of the arXiv API when `max_results` is hitting no response
-    at random `max_results`. If the response does not have entries, we re-try again with a slightly different number
-    for `max_results`.
+    at random `max_results`. If the response does not have entries, we re-try again recursively with a different number
+    for `max_results` until a maximum number of iterations is reached (defined by `max_iteration`).
 
     Args:
         category (str, optional): The arXiv category to fetch papers from. Defaults to "cond-mat.str-el".
         start_index (int, optional): The starting index for fetching papers. Defaults to 0.
         max_results (int, optional): The maximum number of results to fetch. Defaults to 100.
         iteration (int, optional): The current iteration count for recursive attempts. Defaults to 0.
-        max__iteration (int, optional): The maximum number of recursive attempts to fetch papers if no results are found. Defaults to 10.
+        max_iteration (int, optional): The maximum number of recursive attempts to fetch papers if no results are found. Defaults to 10.
         logger (BoundLoggerLazyProxy, optional): The logger to log messages.
 
     Returns:
         list | dict: A list of papers metadata fetched from arXiv. If `max_results` is 1, the batch will be a single dictionary.
     """
     # Recursion safeguard
-    if iteration >= max__iteration:
+    if iteration >= max_iteration:
         logger.warning("Maximum recursion depth reached. Returning empty batch.")
         return []
 
@@ -62,16 +62,16 @@ def get_batch_response(
     batch = data_dict.get("feed", {}).get("entry", [])
 
     # Recursively trying to resolve batches
-    if not batch:
+    if not batch and max_results > 1:
         # try again with a different `max_results`
-        new_max_results = random.randrange(max_results)  # 0 <= value < max_results
+        new_max_results = random.randint(1, max_results - 1)  # 1 <= value < max_results
         iteration += 1
         batch = get_batch_response(
             category=category,
             start_index=start_index,
             max_results=new_max_results,
             iteration=iteration,
-            max__iteration=max__iteration,
+            max_iteration=max_iteration,
         )
         if not batch:
             logger.info("No papers found in the response")
@@ -255,6 +255,7 @@ class ArxivFetcher:
                 batch = [batch]
 
             # Store papers object ArxivPaper in a list
+            print(batch[-1], self.start_index)
             initial_len = len(papers)
             for new_paper in batch:
                 # If there is an error in the fetching, skip the paper

--- a/pyrxiv/fetch.py
+++ b/pyrxiv/fetch.py
@@ -18,7 +18,7 @@ def get_batch_response(
     start_index: int = 0,
     max_results: int = 100,
     iteration: int = 0,
-    max_recursion: int = 10,
+    max__iteration: int = 10,
     logger: "BoundLoggerLazyProxy" = logger,
 ) -> list | dict:
     """
@@ -33,14 +33,14 @@ def get_batch_response(
         start_index (int, optional): The starting index for fetching papers. Defaults to 0.
         max_results (int, optional): The maximum number of results to fetch. Defaults to 100.
         iteration (int, optional): The current iteration count for recursive attempts. Defaults to 0.
-        max_recursion (int, optional): The maximum number of recursive attempts to fetch papers if no results are found. Defaults to 10.
+        max__iteration (int, optional): The maximum number of recursive attempts to fetch papers if no results are found. Defaults to 10.
         logger (BoundLoggerLazyProxy, optional): The logger to log messages.
 
     Returns:
         list | dict: A list of papers metadata fetched from arXiv. If `max_results` is 1, the batch will be a single dictionary.
     """
     # Recursion safeguard
-    if iteration >= max_recursion:
+    if iteration >= max__iteration:
         logger.warning("Maximum recursion depth reached. Returning empty batch.")
         return []
 
@@ -71,7 +71,7 @@ def get_batch_response(
             start_index=start_index,
             max_results=new_max_results,
             iteration=iteration,
-            max_recursion=max_recursion,
+            max__iteration=max__iteration,
         )
         if not batch:
             logger.info("No papers found in the response")


### PR DESCRIPTION
## Summary by Sourcery

Refactor get_batch_response retry logic to use iteration count with a configurable maximum depth, randomize retry batch sizes, and guard against excessive recursion.

Bug Fixes:
- Add recursion depth safeguard to prevent infinite retries when no papers are found
- Log a warning and return an empty batch when maximum recursion depth is reached

Enhancements:
- Replace boolean recursion flag with iteration counter and max__iteration parameter
- Use random.randrange(max_results) for retrying with varied batch sizes instead of a fixed decrement