### PR TITLE
Hotfix comments fetching

### DIFF
--- a/pyrxiv/fetch.py
+++ b/pyrxiv/fetch.py
@@ -305,8 +305,15 @@ class ArxivFetcher:
                     ]
 
                 # Extracting pages and figures from the comment
-                comment = new_paper.get("arxiv:comment", {}).get("#text", "")
-                n_pages, n_figures = self._get_pages_and_figures(comment=comment)
+                comment = ""
+                n_pages, n_figures = None, None
+                try:
+                    comment = new_paper.get("arxiv:comment", {}).get("#text", "")
+                    n_pages, n_figures = self._get_pages_and_figures(comment=comment)
+                except Exception:
+                    self.logger.info(
+                        f"Could not extract comment or number of pages and figures for paper {arxiv_id}."
+                    )
 
                 # Storing the ArxivPaper object in the list
                 papers.append(


### PR DESCRIPTION
This pull request adds error handling to the process of extracting comments and counting pages and figures for papers in the `fetch` method. Now, if there is any issue during extraction, the exception is caught and a log message is recorded, making the code more robust against unexpected data formats.

Error handling improvements:

* Added a `try-except` block around the extraction of `comment`, `n_pages`, and `n_figures` in the `fetch` method of `pyrxiv/fetch.py` to gracefully handle errors and log informative messages when extraction fails.